### PR TITLE
Accept format in the root of a config tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.1.0] - 2019-03-29
+### Added
+ - Accept format in the root of a config tree
+
+### Changed
+ - Update package.json description and add tags. (= "Fork of node-convict", "node-convict") (@A-312)
+
+
 ## [6.0.2] - 2019-03-07
 ### Changed
  - Fix `lerna publish` (@A-312)

--- a/packages/blueconfig/README.md
+++ b/packages/blueconfig/README.md
@@ -260,7 +260,7 @@ const config = blueconfig({
   },
   name: {
     doc: 'user name',
-    format: function check(val, schema) {
+    format: function check(val, schema, fullname) {
       if (typeof val.first_name !== 'string') {
         throw new TypeError(`first name '${val.first_name}' is not a string`);
       }
@@ -282,7 +282,7 @@ method that can be reused for many different properties:
 ```javascript
 blueconfig.addFormat({
   name: 'float-percent',
-  validate: function(val, schema) {
+  validate: function(val, schema, fullname) {
     if (val !== 0 && (!val || val > 1 || val < 0)) {
       throw new Error('must be a float between 0 and 1, inclusive');
     }
@@ -313,7 +313,7 @@ You can specify a custom format checking for array items:
 ```javascript
 blueconfig.addFormat({
   name: 'source-array',
-  validate: function(sources, schema) {
+  validate: function(sources, schema, fullname) {
     if (!Array.isArray(sources)) {
       throw new Error('must be of type Array');
     }
@@ -478,7 +478,7 @@ E.g.:
 ```javascript
 blueconfig.addFormat({
   name: 'float-percent',
-  validate: function(val, validate) {
+  validate: function(val, schema, fullname) {
     if (val !== 0 && (!val || val > 1 || val < 0)) {
       throw new Error('must be a float between 0 and 1, inclusive');
     }
@@ -852,9 +852,9 @@ You will find the properties that you defined in your schema (like `doc`, `defau
 
 Get the name of the getter which gets the current value. 
 
-### schema.\_cvtValidateFormat(value)
+### schema.\_cvtValidateFormat(value, schema, fullname)
 
-Calls the validate format function corresponding to `schema.format`, used by `config.validate(value)` to validate your schema. This function will throw an error if `value` doesn't have the correct format.
+Calls the validate format function corresponding to `schema.format`, used by `config.validate(value, schema, fullname)` to validate your schema. This function will throw an error if `value` doesn't have the correct format.
 
 ### schema.\_cvtCoerce(value)
 

--- a/packages/blueconfig/lib/error.js
+++ b/packages/blueconfig/lib/error.js
@@ -14,6 +14,15 @@ class BLUECONFIG_ERROR extends Error {
 }
 
 
+class LISTOFERRORS extends BLUECONFIG_ERROR {
+  constructor(errors) {
+    super('List of several errors.');
+    this.errors = errors;
+    return this;
+  }
+}
+
+
 // =========================================
 // ============= BLUECONFIG ERROR =============
 // =========================================
@@ -106,6 +115,7 @@ class VALIDATE_FAILED extends BLUECONFIG_ERROR {
     super('Validate failed because wrong value(s):\n' + message);
     this.type = 'VALIDATE_FAILED';
     this.doc = 'You should try to change your config to respect the schema to continue.';
+    this.why = message
     return this;
   }
 }
@@ -126,6 +136,7 @@ class FORMAT_INVALID extends BLUECONFIG_ERROR {
 
 module.exports = {
   BLUECONFIG_ERROR,
+  LISTOFERRORS,
   // 1
   SCHEMA_INVALID,
   // 2

--- a/packages/blueconfig/lib/index.js
+++ b/packages/blueconfig/lib/index.js
@@ -163,7 +163,7 @@ function validate(instance, schema, strictValidation) {
       try {
         instanceItem = walk(instance, name);
       } catch (err) {
-        let message = 'config parameter "' + name + '" missing from config, did you override its parent?';
+        let message = 'config parameter "' + unroot(name) + '" missing from config, did you override its parent?';
         if (err.lastPosition && err.type === 'PATH_INVALID') {
           message += ` Because ${err.why}.`;
         }
@@ -197,7 +197,7 @@ function validate(instance, schema, strictValidation) {
 
   if (strictValidation) {
     Object.keys(flatInstance).forEach(function(name) {
-      const err = new VALUE_INVALID("configuration param '" + name + "' not declared in the schema");
+      const err = new VALUE_INVALID("configuration param '" + unroot(name) + "' not declared in the schema");
       errors.undeclared.push(err);
     });
   }
@@ -543,7 +543,7 @@ function walk(obj, path, initializeMissing) {
       } else {
         const noCvtProp = (path) => path !== '_cvtProperties';
         throw new PATH_INVALID(stringifyPath(path.filter(noCvtProp)), stringifyPath(historic), {
-          path: stringifyPath(historic.slice(0, -1)),
+          path: unroot(stringifyPath(historic.slice(0, -1))),
           value: obj
         }); 
       }
@@ -604,7 +604,7 @@ const blueconfig = function blueconfig(def, opts) {
      * Exports all the properties (that is the keys and their current values) as JSON
      */
     getProperties: function() {
-      return cloneDeep(this._instance);
+      return cloneDeep(this._instance.root);
     },
 
     /**
@@ -613,9 +613,9 @@ const blueconfig = function blueconfig(def, opts) {
      * even if they aren't set, to avoid revealing any information.
      */
     toString: function() {
-      const clone = cloneDeep(this._instance);
+      const clone = cloneDeep(this._instance.root);
       this._sensitive.forEach(function(fullpath) {
-        const path = parsePath(fullpath);
+        const path = parsePath(unroot(fullpath));
         const childKey = path.pop();
         const parentKey = stringifyPath(path);
         const parent = walk(clone, parentKey);
@@ -628,7 +628,7 @@ const blueconfig = function blueconfig(def, opts) {
      * Exports the schema as JSON.
      */
     getSchema: function(debug) {
-      const schema = cloneDeep(this._schema);
+      const schema = cloneDeep(this._schemaRoot);
 
       return (debug) ? cloneDeep(schema) : convertSchema.call(this, schema);
     },
@@ -645,7 +645,7 @@ const blueconfig = function blueconfig(def, opts) {
      *     notation to reference nested values
      */
     get: function(path) {
-      const o = walk(this._instance, path);
+      const o = walk(this._instance.root, path);
       return cloneDeep(o);
     },
 
@@ -655,7 +655,7 @@ const blueconfig = function blueconfig(def, opts) {
      */
     getOrigin: function(path) {
       path = pathToSchemaPath(path, '_cvtGetOrigin');
-      const o = walk(this._schema._cvtProperties, path);
+      const o = walk(this._schemaRoot._cvtProperties, path);
       return o ? o() : null;
     },
 
@@ -691,7 +691,7 @@ const blueconfig = function blueconfig(def, opts) {
       // The default value for FOO.BAR.BAZ is stored in `_schema._cvtProperties` at:
       //   FOO._cvtProperties.BAR._cvtProperties.BAZ.default
       path = pathToSchemaPath(path, 'default');
-      const o = walk(this._schema._cvtProperties, path);
+      const o = walk(this._schemaRoot._cvtProperties, path);
       return cloneDeep(o);
     },
 
@@ -710,7 +710,7 @@ const blueconfig = function blueconfig(def, opts) {
         const r = this.get(path);
         const isRequired = (() => {
           try {
-            return !!walk(this._schema._cvtProperties, pathToSchemaPath(path, 'required'));
+            return !!walk(this._schemaRoot._cvtProperties, pathToSchemaPath(path, 'required'));
           } catch (e) {
             // undeclared property
             return false;
@@ -729,7 +729,7 @@ const blueconfig = function blueconfig(def, opts) {
      * exist, they will be initialized to empty objects
      */
     set: function(fullpath, value, priority, respectPriority) {
-      const mySchema = traverseSchema(this._schema, fullpath);
+      const mySchema = traverseSchema(this._schemaRoot, fullpath);
 
       if (!priority) {
         priority = 'value';
@@ -749,7 +749,7 @@ const blueconfig = function blueconfig(def, opts) {
       const path = parsePath(fullpath);
       const childKey = path.pop();
       const parentKey = stringifyPath(path);
-      const parent = walk(this._instance, parentKey, true);
+      const parent = walk(this._instance.root, parentKey, true);
 
       // respect priority 
       const canIChangeValue = (() => {
@@ -780,15 +780,15 @@ const blueconfig = function blueconfig(def, opts) {
     },
 
     /**
-     * Loads and merges a JavaScript object into config
+     * Merges a JavaScript object into config
      */
     load: function(obj) {
-      applyValues.call(this, obj, this._instance, this._schema);
+      applyValues.call(this, { root: obj }, this._instance, this._schema);
       return this;
     },
 
     /**
-     * Loads and merges one or multiple JSON configuration files into config
+     * Merges a JavaScript properties files into config
      */
     loadFile: function(paths) {
       if (!Array.isArray(paths)) paths = [paths];
@@ -802,6 +802,9 @@ const blueconfig = function blueconfig(def, opts) {
       return this;
     },
 
+    /**
+     * Merges a JavaScript object/files into config
+     */
     merge: function(sources) {
       if (!Array.isArray(sources)) sources = [sources];
       sources.forEach((config) => {
@@ -849,7 +852,7 @@ const blueconfig = function blueconfig(def, opts) {
               err_buf += '[' + err.type + '] ';
             }*/
             if (err.fullName) {
-              err_buf += err.fullName + ': ';
+              err_buf += unroot(err.fullName) + ': ';
             }
             if (err.message) {
               err_buf += err.message;
@@ -917,6 +920,10 @@ const blueconfig = function blueconfig(def, opts) {
     rv._def = def;
   }
 
+  rv._def = {
+    root: rv._def
+  };
+
   // The key `$~default` will be replaced by `default` during the schema parsing that allow
   // to use default key for config properties.
   const optsDefSub = (opts) ? opts.defaultSubstitute : false;
@@ -924,7 +931,10 @@ const blueconfig = function blueconfig(def, opts) {
 
   // build up current config from definition
   rv._schema = {
-    _cvtProperties: {}
+    _cvtProperties: {
+      // root key lets apply format on the config root tree
+      // root: { _cvtProperties: {} }
+    }
   };
 
   rv._getterAlreadyUsed = {};
@@ -938,12 +948,18 @@ const blueconfig = function blueconfig(def, opts) {
     parsingSchema.call(rv, key, rv._def[key], rv._schema._cvtProperties, key);
   });
 
+  rv._schemaRoot = rv._schema._cvtProperties.root;
+
   // config instance
   rv._instance = {};
   applyGetters.call(rv, rv._schema, rv._instance);
 
   return rv;
 };
+
+function unroot(text) {
+  return text.replace(/^root(\.|\[)/g, (_, b) => (b === '[') ? '[' : '');
+}
 
 /**
  * @returns sorted function which sorts array to newOrder

--- a/packages/blueconfig/lib/index.js
+++ b/packages/blueconfig/lib/index.js
@@ -869,6 +869,7 @@ const blueconfig = function blueconfig(def, opts) {
 
             if (!(err instanceof BLUECONFIG_ERROR)) {
               let warning = '[/!\\ this is probably blueconfig internal error]';
+              console.error(err);
               if (process.stdout.isTTY) {
                 warning = BOLD_YELLOW_TEXT + warning + RESET_TEXT;
               }

--- a/packages/blueconfig/test/cases/root_configtree.js
+++ b/packages/blueconfig/test/cases/root_configtree.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const blueconfig = require('blueconfig');
+const LISTOFERRORS = require('blueconfig/lib/error.js').LISTOFERRORS;
+
+function isObjNotNull(obj) {
+  return typeof obj === 'object' && obj !== null;
+}
+
+exports.formats = {
+  children: {
+    validate: function(children, schema, fullname) {
+      const errors = [];
+
+      if (!isObjNotNull(children)) {
+        throw new Error('must be of an Object not null');
+      }
+
+      Object.keys(children).forEach(function(keyname) {
+        try {
+          blueconfig(schema.children).merge(children[keyname]).validate();
+        } catch (err) {
+          err.parent = fullname + '.' + keyname;
+          errors.push(err);
+        }
+      });
+
+      if (errors.length !== 0) {
+        throw new LISTOFERRORS(errors)
+      }
+    }
+  }
+};
+
+exports.conf = {
+  format: 'children',
+  default: {},
+  children: {
+    // conf.{country-name}.xxx:
+    name: {
+      format: 'String',
+      default: undefined,
+      required: true
+    },
+
+    population: {
+      format: 'int',
+      default: 0
+    },
+
+    subregion: {
+      format: 'String',
+      default: undefined,
+      required: true
+    }
+  }
+};
+
+exports.data = {
+  germany: {
+    name: 1,
+    population: '83783942 persons',
+    subregion: 'Western Europe'
+  },
+  france: {
+    name: 'France',
+    population: 65273511,
+    subregion: 'Western Europe'
+  },
+  italy: {
+    name: 'Italy',
+    population: 60461826,
+    subregion: 2
+  }
+};

--- a/packages/blueconfig/test/cases/root_configtree.out
+++ b/packages/blueconfig/test/cases/root_configtree.out
@@ -1,0 +1,6 @@
+Validate failed because wrong value(s):
+  - root: Custom format "children" tried to validate something and failed:
+    1) germany:
+      - name: must be of type String: value was 1
+    2) italy:
+      - subregion: must be of type String: value was 2

--- a/packages/blueconfig/test/cases/root_configtree.string
+++ b/packages/blueconfig/test/cases/root_configtree.string
@@ -1,0 +1,17 @@
+{
+  "germany": {
+    "name": 1,
+    "population": "83783942 persons",
+    "subregion": "Western Europe"
+  },
+  "france": {
+    "name": "France",
+    "population": 65273511,
+    "subregion": "Western Europe"
+  },
+  "italy": {
+    "name": "Italy",
+    "population": 60461826,
+    "subregion": 2
+  }
+}

--- a/packages/blueconfig/test/schema-tests.js
+++ b/packages/blueconfig/test/schema-tests.js
@@ -85,9 +85,6 @@ describe('blueconfig schema', function() {
       }
     });
 
-    console.log(requiredStringandUndefined.getSchema());
-    console.log(requiredStringandUndefined.getSchema());
-
     const expected = 'Validate failed because wrong value(s):\n'
       + '  - foo.none: must be of type String\n'
       + '  - foo.none2: must be of type String';

--- a/packages/blueconfig/test/validation-tests.js
+++ b/packages/blueconfig/test/validation-tests.js
@@ -283,7 +283,13 @@ describe('schema contains an object property with a custom format', function() {
     // init the hack (replace _cvtValidateFormat by our own function)
     expect(() => conf.validate(strictMode)).not.to.throw();
 
+    // hide error displaying
+    const error = global.console.error = () => {}
+
     // run the hack function
     expect(() => conf.validate(strictMode)).to.throw(message + ' \x1b[33;1m[/!\\ this is probably blueconfig internal error]\x1b[0m');
+    
+    // restart debug
+    global.console.error = error;
   });
 });


### PR DESCRIPTION
This PR let we do something like that:

```json
{
  "germany": {
    "name": "Germany",
    "population": 83783942,
    "subregion": "Western Europe"
  },
  "france": {
    "name": "France",
    "population": 65273511,
    "subregion": "Western Europe"
  },
  "italy": {
    "name": "Italy",
    "population": 60461826,
    "subregion": "Southern Europe"
  }
}
```


```js
'use strict';

const path = require('path');

const blueconfig = require('blueconfig');
const LISTOFERRORS = require('blueconfig/lib/error.js').LISTOFERRORS;

function isObjNotNull(obj) {
  return typeof obj === 'object' && obj !== null;
}

blueconfig.addFormat({
  name: 'children',
  validate: function(children, schema, fullname) {
    const errors = [];

    if (!isObjNotNull(children)) {
      throw new Error('must be of an Object not null');
    }

    Object.keys(children).forEach(function(keyname) {
      try {
        blueconfig(schema.children).merge(children[keyname]).validate();
      } catch (err) {
        err.parent = fullname + '.' + keyname;
        errors.push(err);
      }
    });

    if (errors.length !== 0) {
      throw new LISTOFERRORS(errors)
    }
  }
});

let conf = blueconfig({
  format: 'children',
  default: {},
  children: {
    // conf.{country-name}.xxx:
    name: '',
    population: 0,
    subregion: ''
  }
}).merge(path.join(__dirname, 'config.json')).validate();

console.log(conf.getProperties())
```